### PR TITLE
Обновление build.gradle для react-native 0.71

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,20 +4,30 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath("com.android.tools.build:gradle:1.1.3")
     }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
+
+    buildToolsVersion "33.0.0"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
+        versionCode 13
+        versionName "1.0.0"
+    }
+    lintOptions {
+        abortOnError false
     }
     buildTypes {
         release {
@@ -30,11 +40,10 @@ android {
 
 repositories {
     mavenCentral()
-    maven { url "https://jitpack.io" }
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.facebook.react:react-native:+'
-    compile 'ru.ok:odnoklassniki-android-sdk:2.1.6'
+    implementation('com.android.support:appcompat-v7:25.0.0')
+    implementation('com.facebook.react:react-native:+')
+    implementation('ru.ok:odnoklassniki-android-sdk:2.1.6')
 }


### PR DESCRIPTION
1. Убран deprecate плагин maven.
2. Изменена конфигурация зависимостей с декоратора compile(deprecated  Gradle 7.0+) на implementation 
3. Добавлена автоматическая верификация из родительского gradle